### PR TITLE
LoopHelper: Fix overflow panic when looping u32 max times

### DIFF
--- a/src/loop_helper.rs
+++ b/src/loop_helper.rs
@@ -125,7 +125,7 @@ impl LoopHelper {
         let delta = it_start.duration_since(self.last_loop_start);
         self.last_loop_start = it_start;
         self.delta_sum += delta;
-        self.delta_count += 1;
+        self.delta_count = self.delta_count.wrapping_add(1);
         delta
     }
 


### PR DESCRIPTION
Note: Only affects builds with integer overflow checks, e.g. debug builds, and where report_rate is never called.

Resolves #14 