### PR TITLE
Windows: Remove once_cell dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased (v1.2.0)
+* Windows: Remove _once_cell_ dependency.
+
 # v1.1.1
 * Fix LoopHelper increment overflow handling.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ readme="README.md"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["minwindef", "mmsystem", "timeapi"] }
-once_cell = "1"
 
 [dev-dependencies]
 approx = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ impl Default for SpinSleeper {
     #[inline]
     fn default() -> Self {
         #[cfg(windows)]
-        let accuracy = *MIN_TIME_PERIOD * 1_000_000;
+        let accuracy = windows::min_time_period() * 1_000_000;
         #[cfg(not(windows))]
         let accuracy = DEFAULT_NATIVE_SLEEP_ACCURACY;
 
@@ -198,13 +198,11 @@ pub enum SpinStrategy {
 /// * !Windows `YieldThread`
 impl Default for SpinStrategy {
     #[inline]
-    #[cfg(windows)]
     fn default() -> Self {
-        Self::SpinLoopHint
-    }
-    #[inline]
-    #[cfg(not(windows))]
-    fn default() -> Self {
+        #[cfg(windows)]
+        return Self::SpinLoopHint;
+
+        #[cfg(not(windows))]
         Self::YieldThread
     }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -9,7 +9,7 @@ use winapi::{
 
 #[inline]
 pub fn native_sleep(duration: Duration) {
-    let min_time_period = win_min_time_period();
+    let min_time_period = min_time_period();
     unsafe {
         timeBeginPeriod(min_time_period);
         std::thread::sleep(duration);
@@ -17,7 +17,7 @@ pub fn native_sleep(duration: Duration) {
     }
 }
 
-fn win_min_time_period() -> UINT {
+pub(crate) fn min_time_period() -> UINT {
     static MIN_TIME_PERIOD: OnceLock<UINT> = OnceLock::new();
 
     *MIN_TIME_PERIOD.get_or_init(|| {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,0 +1,36 @@
+use std::{mem, sync::OnceLock, time::Duration};
+use winapi::{
+    shared::minwindef::UINT,
+    um::{
+        mmsystem::{TIMECAPS, TIMERR_NOERROR},
+        timeapi::{timeBeginPeriod, timeEndPeriod, timeGetDevCaps},
+    },
+};
+
+#[inline]
+pub fn native_sleep(duration: Duration) {
+    let min_time_period = win_min_time_period();
+    unsafe {
+        timeBeginPeriod(min_time_period);
+        std::thread::sleep(duration);
+        timeEndPeriod(min_time_period);
+    }
+}
+
+fn win_min_time_period() -> UINT {
+    static MIN_TIME_PERIOD: OnceLock<UINT> = OnceLock::new();
+
+    *MIN_TIME_PERIOD.get_or_init(|| {
+        let tc_size = mem::size_of::<TIMECAPS>() as u32;
+        let mut tc = TIMECAPS {
+            wPeriodMin: 0,
+            wPeriodMax: 0,
+        };
+
+        if timeGetDevCaps(&mut tc as *mut TIMECAPS, tc_size) == TIMERR_NOERROR {
+            tc.wPeriodMin
+        } else {
+            1
+        }
+    })
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -20,7 +20,7 @@ pub fn native_sleep(duration: Duration) {
 pub(crate) fn min_time_period() -> UINT {
     static MIN_TIME_PERIOD: OnceLock<UINT> = OnceLock::new();
 
-    *MIN_TIME_PERIOD.get_or_init(|| {
+    *MIN_TIME_PERIOD.get_or_init(|| unsafe {
         let tc_size = mem::size_of::<TIMECAPS>() as u32;
         let mut tc = TIMECAPS {
             wPeriodMin: 0,


### PR DESCRIPTION
Rework windows code and remove _once_cell_ usage in favour of std `OnceLock`.